### PR TITLE
Allow wildcards in rule_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Now, run `dogpush diff` again, and see that the difference will be empty. Your
 local rules are in sync with your DataDog rules.  If you have a lot of rules,
 You may split your initial rules file to multiple files (by category, or
 team), and include all of them in the `rule_files` section.  Paths can be
-either relative to the config file or absolute.
+either relative to the config file or absolute. Paths may contain wildcards.
 
 ```
 rule_files:
@@ -83,13 +83,7 @@ rule_files:
 - ec2.yaml
 - dir1/rules.yaml
 - /absolute/path/to/rules.yaml
-```
-
-Alternatively, you can specify a directory for your rules, and all YAML files
-within that directory will be included.
-
-```
-rule_directory: my_rules/
+- path/with/wildcard/*.yaml
 ```
 
 Now you can make changes to your rule files. See the changes by running

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ rule_files:
 - /absolute/path/to/rules.yaml
 ```
 
+Alternatively, you can specify a directory for your rules, and all YAML files
+within that directory will be included.
+
+```
+rule_directory: my_rules/
+```
+
 Now you can make changes to your rule files. See the changes by running
 `dogpush diff`, and push them using `dogpush push`.
 
@@ -202,4 +209,3 @@ period described by `mute_when` is over.  This command can be run
 from a cron job to ensure monitors are silenced at the right times. As the
 mute automatically expires, there is no need to run anything to unmute the
 alerts.
-

--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -20,3 +20,5 @@ mute_tags:
 rule_files:
 - rds.yaml
 
+# Optionally specify a directory of rule YAML files:
+# rule_directory: rules/

--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -19,6 +19,3 @@ mute_tags:
 
 rule_files:
 - rds.yaml
-
-# Optionally specify a directory of rule YAML files:
-# rule_directory: rules/

--- a/dogpush/dogpush.py
+++ b/dogpush/dogpush.py
@@ -5,7 +5,7 @@ import calendar
 import copy
 import datetime
 import difflib
-import json
+import glob
 import os
 import re
 import sys
@@ -120,7 +120,7 @@ def _canonical_monitor(original, default_team=None, **kwargs):
 def get_datadog_monitors():
     monitors = datadog.api.Monitor.get_all()
     if not _check_monitor_names_unique(monitors):
-        raise DataDogException(
+        raise DogPushException(
             'Duplicate names found in remote datadog monitors.')
     result = {}
     for m in monitors:
@@ -148,41 +148,30 @@ def _check_monitor(monitor, location):
     if not name:
         raise DogPushException('%s: found monitor without a name' % location)
 
-def _read_monitor_file(filename):
-    monitors = []
-    with open(filename, 'r') as f:
-        r = yaml.safe_load(f)
-        if r is None:
-            r = {alerts: []}
-        if not isinstance(r, dict):
-            raise DogPushException("Expected a dictionary")
-        if not isinstance(r.get('alerts'), list):
-            raise DogPushException("'alerts' must be a list of alerts.")
-        default_team = r.get('team')
-        for monitor in r['alerts']:
-            _check_monitor(monitor, filename)
-            monitors.append(_canonical_monitor(monitor, filename=filename,
-                                               default_team=default_team))
-    return monitors
-
 
 def get_local_monitors():
-    l = CONFIG.get('rule_files', [])
     monitors = []
-    for filename in l:
-        filename = filename if os.path.isabs(filename) else os.path.join(
-                CONFIG_DIR, filename)
-        monitors += _read_monitor_file(filename)
-    rule_directory = CONFIG.get('rule_directory')
-    if rule_directory:
-        if not os.path.isabs(rule_directory):
-            rule_directory = os.path.join(CONFIG_DIR, rule_directory)
-        for filename in os.listdir(rule_directory):
-            if filename.endswith('.yml') or filename.endswith('.yaml'):
-                filename = os.path.join(rule_directory, filename)
-                monitors += _read_monitor_file(filename)
+    for globname in CONFIG.get('rule_files', []):
+        if not os.path.isabs(globname):
+            globname = os.path.join(CONFIG_DIR, globname)
+        for filename in glob.glob(globname):
+            with open(filename, 'r') as f:
+                r = yaml.safe_load(f)
+                if r is None:
+                    r = {'alerts': []}
+                if not isinstance(r, dict):
+                    raise DogPushException("Expected a dictionary")
+                if not isinstance(r.get('alerts'), list):
+                    raise DogPushException("'alerts' must be a list of alerts.")
+                default_team = r.get('team')
+                for monitor in r['alerts']:
+                    _check_monitor(monitor, filename)
+                    monitor = _canonical_monitor(monitor,
+                                                 filename=filename,
+                                                 default_team=default_team)
+                    monitors.append(monitor)
     if not _check_monitor_names_unique(monitors):
-        raise DataDogException('Duplicate names found in local monitors.')
+        raise DogPushException('Duplicate names found in local monitors.')
     result = dict((m['name'], m) for m in monitors)
     return result
 


### PR DESCRIPTION
Allow an entire directory of rule files to be included. An example configuration would look like:

``` yaml

---
datadog:
  api_key: YOUR_API_KEY
  app_key: YOUR_APP_KEY

rule_directory: my_rules
```
