### PR TITLE
Expose DataDog API errors by default

### DIFF
--- a/dogpush/dogpush.py
+++ b/dogpush/dogpush.py
@@ -36,6 +36,7 @@ def _load_config(config_file):
             'app_key', os.getenv('DATADOG_APP_KEY'))
     config['datadog']['api_key'] = config['datadog'].get(
             'api_key', os.getenv('DATADOG_API_KEY'))
+    config['datadog']['mute'] = config['datadog'].get('mute', False)
     if 'default_rule_options' not in config:
         config['default_rule_options'] = LOCAL_DEFAULT_RULE_OPTIONS
 


### PR DESCRIPTION
This fixes #1 

Previously, with an erroneous query:

```
$ dogpush push
Pushing 1 new monitors.
```

And now, with this change:

```
$ dogpush push
datadog.api.exceptions.ApiError: {'errors': ["The value provided for parameter 'query' is invalid"]}
```
