### PR TITLE
Add --delete option to push command

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ Pushes the local monitors to datadog:
 - will update existing monitors (so it could override what you were doing if
   you edit an existing monitor in datadog)
 - will not remove or touch untracked monitors (that is, datadog monitors
-  that are not in any of the yaml files) unless the `--delete` flag is
-  passed in.
+  that are not in any of the yaml files) unless the `--delete_untracked` flag
+  is passed in.
 
 This command can run from a cronjob to ensure the monitors on DataDog are
 synchronized with the local monitors.

--- a/README.md
+++ b/README.md
@@ -206,8 +206,9 @@ Pushes the local monitors to datadog:
 - will create new monitors
 - will update existing monitors (so it could override what you were doing if
   you edit an existing monitor in datadog)
-- will *never* remove or touch untracked monitors (that is, datadog monitors
-  that are not any of the yaml files).
+- will not remove or touch untracked monitors (that is, datadog monitors
+  that are not in any of the yaml files) unless the `--delete` flag is
+  passed in.
 
 This command can run from a cronjob to ensure the monitors on DataDog are
 synchronized with the local monitors.

--- a/dogpush/dogpush.py
+++ b/dogpush/dogpush.py
@@ -211,7 +211,7 @@ def _is_changed(local, remote):
     return local['obj'] != remote['obj']
 
 
-def command_init():
+def command_init(args):
     remote_monitors = [m['obj'] for m in get_datadog_monitors().values()]
     monitors = {'alerts': remote_monitors}
     print '# team: TEAMNAME'
@@ -219,7 +219,7 @@ def command_init():
     print _pretty_yaml(monitors)
 
 
-def command_push():
+def command_push(args):
     local_monitors = get_local_monitors()
     remote_monitors = get_datadog_monitors()
 
@@ -233,11 +233,19 @@ def command_push():
     changed = [name for name in common_names
                if _is_changed(local_monitors[name], remote_monitors[name])]
     if changed:
-        print "Updating %d modified alerts" % len(changed)
+        print "Updating %d modified monitors." % len(changed)
         for name in changed:
             datadog.api.Monitor.update(
                 remote_monitors[name]['id'],
                 **_prepare_monitor(local_monitors[name]))
+
+    if args.delete:
+        remote_monitors = get_datadog_monitors()
+        untracked = set(remote_monitors.keys()) - set(local_monitors.keys())
+        if untracked:
+            print "Deleting %d untracked monitors." % len(untracked)
+            for monitor in untracked:
+                datadog.api.Monitor.delete(remote_monitors[monitor]['id'])
 
 
 def _should_mute(expr, tz, now):
@@ -261,7 +269,7 @@ def _mute_until(expr, tz, now):
     return now
 
 
-def command_mute():
+def command_mute(args):
     local_monitors = get_local_monitors()
     remote_monitors = get_datadog_monitors()
     mute_tags = {}
@@ -292,7 +300,7 @@ def command_mute():
                                                       mute_until['datetime'])
 
 
-def command_diff():
+def command_diff(args):
     local_monitors = get_local_monitors()
     remote_monitors = get_datadog_monitors()
 
@@ -358,7 +366,7 @@ parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
 
-parser.add_argument('--config', '-c',
+parser.add_argument('-c', '--config',
                     default=os.path.join('.', 'config.yaml'),
                     help='configuration file to load')
 
@@ -366,18 +374,20 @@ subparsers = parser.add_subparsers(help='sub-command help')
 
 
 parser_push = subparsers.add_parser(
-    'init', help='init new alerts file')
+    'init', help='Init new alerts file')
 parser_push.set_defaults(command=command_init)
 
 
 parser_push = subparsers.add_parser(
-    'push', help='push monitors to datadog')
+    'push', help='Push monitors to DataDog.')
+parser_push.add_argument('-d', '--delete', action='store_true',
+                         help='Delete untracked monitors.')
 parser_push.set_defaults(command=command_push)
 
 
 parser_diff = subparsers.add_parser(
     'diff',
-    help='show diff between local monitors and datadog')
+    help='Show diff between local monitors and DataDog')
 parser_diff.set_defaults(command=command_diff)
 
 
@@ -394,7 +404,7 @@ CONFIG_DIR = os.path.abspath(os.path.dirname(args.config))
 
 def main():
     datadog.initialize(**CONFIG['datadog'])
-    args.command()
+    args.command(args)
 
 
 if __name__ == '__main__':

--- a/dogpush/dogpush.py
+++ b/dogpush/dogpush.py
@@ -239,7 +239,7 @@ def command_push(args):
                 remote_monitors[name]['id'],
                 **_prepare_monitor(local_monitors[name]))
 
-    if args.delete:
+    if args.delete_untracked:
         remote_monitors = get_datadog_monitors()
         untracked = set(remote_monitors.keys()) - set(local_monitors.keys())
         if untracked:
@@ -380,7 +380,7 @@ parser_push.set_defaults(command=command_init)
 
 parser_push = subparsers.add_parser(
     'push', help='Push monitors to DataDog.')
-parser_push.add_argument('-d', '--delete', action='store_true',
+parser_push.add_argument('-d', '--delete_untracked', action='store_true',
                          help='Delete untracked monitors.')
 parser_push.set_defaults(command=command_push)
 


### PR DESCRIPTION
~The sync command is used to sync remote monitor state with local monitor state. This means creating, updating, and deleting monitors as needed.~

Fixes https://github.com/trueaccord/DogPush/issues/8 and, assuming all monitors are tracked in code, https://github.com/trueaccord/DogPush/issues/7 as well.