### PR TITLE
Ignore untracked, ignore prefix and yaml_width

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ Pushes the local monitors to datadog:
 - will update existing monitors (so it could override what you were doing if
   you edit an existing monitor in datadog)
 - will not remove or touch untracked monitors (that is, datadog monitors
-  that are not in any of the yaml files) unless the `--delete` flag is
-  passed in.
+  that are not in any of the yaml files) unless the `--delete_untracked` flag
+  is passed in.
 
 This command can run from a cronjob to ensure the monitors on DataDog are
 synchronized with the local monitors.

--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ Pushes the local monitors to datadog:
 - will update existing monitors (so it could override what you were doing if
   you edit an existing monitor in datadog)
 - will not remove or touch untracked monitors (that is, datadog monitors
-  that are not in any of the yaml files) unless the `--delete_untracked` flag
-  is passed in.
+  that are not in any of the yaml files) unless the `--delete` flag is
+  passed in.
 
 This command can run from a cronjob to ensure the monitors on DataDog are
 synchronized with the local monitors.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ See `config-sample.yaml` for a full example.
 
 ### DogPush options
 
-There are two optional settings that can be configured in the confi file:
+There are two optional settings that can be configured in the config file:
 
 ```yaml
 dogpush:

--- a/README.md
+++ b/README.md
@@ -170,6 +170,21 @@ automatically mute these alerts.
 
 See `config-sample.yaml` for a full example.
 
+### DogPush options
+
+There are two optional settings that can be configured in the confi file:
+
+```yaml
+dogpush:
+  yaml_width: 80
+  ignore_prefix: 'string'
+```
+
+The `yaml_width` option sets the line width of the generated yaml output. 
+
+Using `ignore_prefix` one can define a set of monitor names that are 
+simply ignored by DogPush when fetching the remote monitors.
+
 ## Rule files
 
 On the top of a rules file you can define `team: xyz` to define the default

--- a/dogpush/dogpush.py
+++ b/dogpush/dogpush.py
@@ -344,7 +344,7 @@ def command_diff(args):
                     sys.stdout.write(bcolors.GREEN + line + bcolors.ENDC)
                 else:
                     sys.stdout.write(line)
-    if only_remote:
+    if only_remote and not args.ignore_untracked:
         sys.stdout.write(bcolors.WARNING)
         print '------------------------------------------------------------'
         print ' UNTRACKED MONITORS.  These monitors are only in datadog    '
@@ -388,6 +388,8 @@ parser_push.set_defaults(command=command_push)
 parser_diff = subparsers.add_parser(
     'diff',
     help='Show diff between local monitors and DataDog')
+parser_diff.add_argument('-i', '--ignore_untracked', action='store_true',
+                         help='Ignore untracked monitors.')
 parser_diff.set_defaults(command=command_diff)
 
 

--- a/dogpush/dogpush.py
+++ b/dogpush/dogpush.py
@@ -368,6 +368,7 @@ def command_diff(args):
         sys.stdout.write(bcolors.FAIL)
         print "*** FAILED *** Untracked monitors found."
         sys.stdout.write(bcolors.ENDC)
+    if any((only_local, changed, only_remote and not args.ignore_untracked)):
         sys.exit(1)
 
 

--- a/dogpush/dogpush.py
+++ b/dogpush/dogpush.py
@@ -239,7 +239,7 @@ def command_push(args):
                 remote_monitors[name]['id'],
                 **_prepare_monitor(local_monitors[name]))
 
-    if args.delete:
+    if args.delete_untracked:
         remote_monitors = get_datadog_monitors()
         untracked = set(remote_monitors.keys()) - set(local_monitors.keys())
         if untracked:
@@ -380,7 +380,7 @@ parser_push.set_defaults(command=command_init)
 
 parser_push = subparsers.add_parser(
     'push', help='Push monitors to DataDog.')
-parser_push.add_argument('-d', '--delete', action='store_true',
+parser_push.add_argument('-d', '--delete_untracked', action='store_true',
                          help='Delete untracked monitors.')
 parser_push.set_defaults(command=command_push)
 

--- a/dogpush/dogpush.py
+++ b/dogpush/dogpush.py
@@ -239,7 +239,7 @@ def command_push(args):
                 remote_monitors[name]['id'],
                 **_prepare_monitor(local_monitors[name]))
 
-    if args.delete_untracked:
+    if args.delete:
         remote_monitors = get_datadog_monitors()
         untracked = set(remote_monitors.keys()) - set(local_monitors.keys())
         if untracked:
@@ -380,7 +380,7 @@ parser_push.set_defaults(command=command_init)
 
 parser_push = subparsers.add_parser(
     'push', help='Push monitors to DataDog.')
-parser_push.add_argument('-d', '--delete_untracked', action='store_true',
+parser_push.add_argument('-d', '--delete', action='store_true',
                          help='Delete untracked monitors.')
 parser_push.set_defaults(command=command_push)
 


### PR DESCRIPTION
Here's a PR with some features we are missing in DogPush:

- `--ignore_untracked` in the `diff` command will simply ignore remote only monitors
- diff will exit non zero wether there is a difference between remote and local
- `dogpush.ignore_prefix` setting in the global configuration file allows excluding a set of monitors from being fetched by dogpush
- `dogpush.yaml_width` allows customising the YAML width when generating output.

Thank you for DogPush, we're loving it.

Based this PR on @AMeng https://github.com/trueaccord/DogPush/pull/9 - hope that one gets merged first.