### PR TITLE
ignore overall_state_modified

### DIFF
--- a/dogpush/dogpush.py
+++ b/dogpush/dogpush.py
@@ -56,7 +56,7 @@ SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 # Datadog fields we do not store locally.
 IGNORE_FIELDS = ['created_at', 'created', 'modified', 'creator',
-                 'org_id', 'overall_state', 'id', 'deleted',
+                 'org_id', 'overall_state', 'overall_state_modified', 'id', 'deleted',
                  'matching_downtimes',
                  # dogpush specific:
                  'mute_when', 'team', 'severity']


### PR DESCRIPTION
Hi,

We added an additional field to keep track of the last time the overall state was modified. It appears this broke this tool.

Apologies for introducing a backwards-incompatible change. We were working under the assumption that whereas removing or renaming fields would cause problems for customers, simply adding a new field would not, but it looks like that assumption was wrong.

I presume this should fix the problem, though it's probably worth updating the code in some way to be more tolerant of added fields.

- Caleb Doxsey (caleb@datadoghq.com)