### PR TITLE
Refactor severity to use monitor thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,30 +117,27 @@ default_rule_options:
 
 ### The teams section
 
-Teams in DogPush are just a way to append some text to the message body of a
-monitor so it will grab the attention of the right people. By defining your
+Teams in DogPush are a way to append notification methods in a conditional fashion
+to so it will grab the attention of the right people. By defining your
 teams in the global config, it is super easy to add these @-mentions to all
 your monitors. For example,
 ```yaml
 teams:
   eng:
     notifications:
-      CRITICAL: '@hipchat-Engineering @victorops-eng'
-      WARNING: '@eng-alerts@example.com'
+      alert: '@hipchat-Engineering @victorops-eng'
+      warning: '@eng-alerts@example.com'
   ops:
     notifications:
-      CRITICAL: '@hipchat-Ops'
+      alert: '@hipchat-Ops'
 ```
 
-means that any monitor of severity `CRITICAL` to the `eng` team will have the
-'@hipchat-Engineering @victorops-eng' appending to its message body.
+means that when an monitor metric reaches the alert threshold the `eng` team
+will be notfied via '@hipchat-Engineering @victorops-eng'.
 
 Then, in a rules file, you can have a top level `team` setting (making all
 the alerts automatically go to that team), or specify 'team' at the alert
 level.
-
-The default severity is `CRITICAL`, and you can override the severity in each
-monitor by using the `severity` key.
 
 ### Muting alerts based on time windows
 
@@ -180,9 +177,9 @@ dogpush:
   ignore_prefix: 'string'
 ```
 
-The `yaml_width` option sets the line width of the generated yaml output. 
+The `yaml_width` option sets the line width of the generated yaml output.
 
-Using `ignore_prefix` one can define a set of monitor names that are 
+Using `ignore_prefix` one can define a set of monitor names that are
 simply ignored by DogPush when fetching the remote monitors.
 
 ## Rule files

--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -6,11 +6,15 @@ datadog:
 teams:
   eng:
     notifications:
-      alert: '@hipchat-Engineering @victorops-eng'
-      warning: '@eng-alerts@example.com'
+      alert: 
+      - '@hipchat-Engineering'
+      - '@victorops-eng'
+      warning:
+      - '@eng-alerts@example.com'
   ops:
     notifications:
-      alert: '@hipchat-Ops'
+      alert:
+      - '@hipchat-Ops'
 
 mute_tags:
   not_business_hours:

--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -6,11 +6,11 @@ datadog:
 teams:
   eng:
     notifications:
-      CRITICAL: '@hipchat-Engineering @victorops-eng'
-      WARNING: '@eng-alerts@example.com'
+      alert: '@hipchat-Engineering @victorops-eng'
+      warning: '@eng-alerts@example.com'
   ops:
     notifications:
-      CRITICAL: '@hipchat-Ops'
+      alert: '@hipchat-Ops'
 
 mute_tags:
   not_business_hours:

--- a/dogpush/dogpush.py
+++ b/dogpush/dogpush.py
@@ -53,9 +53,6 @@ def _load_config(config_file):
     return config
 
 
-SEVERITIES = ['CRITICAL', 'WARNING', 'INFO']
-
-
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
@@ -118,14 +115,12 @@ def _canonical_monitor(original, default_team=None, **kwargs):
     m['name'] = m['name'].strip()
     original_team = original.get('team')
     team = original_team if original_team is not None else default_team
-    severity = original.get('severity') or 'CRITICAL'
     if team:
         if isinstance(team, basestring):
             team = [team]
         m['message'] = m.get('message', '')
-        for t in team:
-            dogpush_line = CONFIG['teams'][t]['notifications'][severity]
-            m['message'] += ('\n' if m['message'] else '') + dogpush_line
+        dogpush_line = get_notify_string(team)
+        m['message'] += ('\n' if m['message'] else '') + dogpush_line
 
     result = dict(
         name = m['name'],
@@ -136,6 +131,31 @@ def _canonical_monitor(original, default_team=None, **kwargs):
     )
     result.update(kwargs)
     return result
+
+
+def get_notify_string(teams):
+    """Build notification string."""
+    is_warning = ''
+    is_alert = ''
+    is_recovery = ''
+    notification_items = {'warning': [], 'alert': [], 'recovery': []}
+    for team in teams:
+        for notification in ['warning', 'alert']:
+            try:
+                for item in CONFIG['teams'][team]['notifications'][notification]:
+                    if item not in notification_items[notification]:
+                        notification_items[notification].append(item)
+                    if item not in notification_items['recovery']:
+                        notification_items['recovery'].append(item)
+            except KeyError:
+                pass
+    for warning in notification_items['warning']:
+        is_warning += " {}\n".format(warning)
+    for alert in notification_items['alert']:
+        is_alert += " {}\n".format(alert)
+    for recovery in notification_items['recovery']:
+        is_recovery += " {}\n".format(recovery)
+    return "{{#is_warning}}\n{}{{/is_warning}}\n{{#is_alert}}\n{}{{/is_alert}}\n{{#is_recovery}}\n{}{{/is_recovery}}".format(is_warning, is_alert, is_recovery)
 
 
 def get_datadog_monitors():


### PR DESCRIPTION
On our team we wanted a way to centralize the management of both our monitors, but also the conditional notifications in the monitors' messages. This PR ties a team's severity notifications to the alert threshold. Instead of setting a monitor to have a certain severity, the message will have conditional blocks containing the appropriate notification channels based on the threshold of the alert. I also put all notifications into a `is_recovery` block so that alerts auto resolve as expected.

Nothing new is required in the config, and all fields are optional. 

Example message:
````
{#is_warning}
 @slack-cloud-operations
 @slack-product-support
{/is_warning}
{#is_alert}
 @slack-cloud-operations
 @pagerduty-CloudOperations
 @slack-product-support
 @pagerduty-ProductSupport
{/is_alert}
{#is_recovery}
 @slack-cloud-operations
 @pagerduty-CloudOperations
 @slack-product-support
 @pagerduty-ProductSupport
{/is_recovery}
````