### PR TITLE
Add filter by mention

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -19,3 +19,10 @@ mute_tags:
 
 rule_files:
 - rds.yaml
+
+dogpush:
+  yaml_width: 80
+  ignore_prefix: 'string'
+  filter_by_at_mention:
+  - '@victorops-eng'
+  - '@hipchat-Engineering'


### PR DESCRIPTION
DataDog is used by several teams in our organization. Our team would like to use DogPush to enforce an SDLC pattern for our monitors without affecting other teams.
This PR will allow us to focus only on the alerts mentioning our team.