### PR TITLE
Use safe dump when printing yaml

### DIFF
--- a/dogpush/dogpush.py
+++ b/dogpush/dogpush.py
@@ -90,7 +90,7 @@ DATADOG_DEFAULT_RULES = {
 
 def _pretty_yaml(d):
     return re.sub('^-', '\n-',
-                  yaml.dump(d, width=CONFIG['dogpush']['yaml_width']), flags=re.M)
+                  yaml.safe_dump(d, width=CONFIG['dogpush']['yaml_width']), flags=re.M)
 
 
 # Transform a monitor to a canonical form by removing defaults


### PR DESCRIPTION
A fix for #19. All credit to @ewhauser, I just didn't see a PR. 