### PR TITLE
allow locked and notify_audit as default fields

### DIFF
--- a/dogpush/dogpush.py
+++ b/dogpush/dogpush.py
@@ -76,7 +76,7 @@ LOCAL_DEFAULT_RULE_OPTIONS = {
   'notify_no_data': True,
   'renotify_interval': 15,
   'notify_audit': False,
-  'locked': False,
+  'locked': False
 }
 
 DATADOG_DEFAULT_OPTIONS = {

--- a/dogpush/dogpush.py
+++ b/dogpush/dogpush.py
@@ -75,11 +75,11 @@ IGNORE_OPTIONS = ['silenced']
 LOCAL_DEFAULT_RULE_OPTIONS = {
   'notify_no_data': True,
   'renotify_interval': 15,
+  'notify_audit': False,
+  'locked': False,
 }
 
 DATADOG_DEFAULT_OPTIONS = {
-  'notify_audit': False,
-  'locked': False,
   'silenced': {}
 }
 


### PR DESCRIPTION
**What happened**:
AssertionError
```
bash-4.3# dogpush -c config.yaml diff
Diffing local files against datadog...
Traceback (most recent call last):
  File "/usr/local/bin/dogpush", line 3, in <module>
    from dogpush import dogpush
  File "/usr/local/lib/python2.7/site-packages/dogpush/dogpush.py", line 416, in <module>
    CONFIG = _load_config(args.config)
  File "/usr/local/lib/python2.7/site-packages/dogpush/dogpush.py", line 51, in _load_config
    set(DATADOG_DEFAULT_OPTIONS.keys()) == set())
AssertionError
```

**What you expected to happen**:
I expect to be able to set the following config in my config file (as per the example):
```yaml
default_rule_options:
  notify_audit: True
  locked: True
```
And I expect that default option to propagate to my rules

**How to reproduce it (as minimally and precisely as possible)**:
Set the following in the top level config file (along with all your other settings).
```yaml
default_rule_options:
  notify_audit: True
  locked: True
```
run `dogpush -c config.yaml diff`

This PR moves the defaults from the non-overwritable list to the overwritable list. I have tested that this works locally with the `diff` arg, but not sure what other considerations this impacts.